### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Then, build the binary:
 ## Usage
 After building the binary, run as
 
-`./ipfs-blockchain-watcher watch --config=<config_file.toml`
+`./ipfs-blockchain-watcher watch --config=config_file.toml`
 
 ### Configuration
 


### PR DESCRIPTION
I noticed when running `./ipfs-blockchain-watcher watch --config=<config_file.toml` it told me `WARN[2020-08-08T11:01:25-07:00] No config file passed with --config flag`

When I removed `<` from `--config=<config_file.toml` it started to tell me `INFO[2020-08-08T11:04:47-07:00] Using config file: config_file.toml` instead.